### PR TITLE
fix for new home assistant

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,10 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: config_entries.ConfigEnt
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = xr18_mixer
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     def handle_helper_state_change(event):
         new_state = event.data.get("new_state")


### PR DESCRIPTION
```
  File "/config/custom_components/behringer_xr18/__init__.py", line 33, in async_setup_entry
    hass.config_entries.async_forward_entry_setup(entry, platform)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'. Did you mean: 'async_forward_entry_setups'?
```

crashes in prod.

https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/